### PR TITLE
Changes to build to be compatible with Windows11

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,16 +1,15 @@
 {
-    "configurations": [
-        {
-            "name": "Linux",
-            "compileCommands": [
-                "${workspaceRoot}/build/compile_commands.json"
-            ],
-            "compilerPath": "/usr/bin/clang-19",
-            "cStandard": "c17",
-            "cppStandard": "c++17",
-            "intelliSenseMode": "linux-clang-x64",
-            "configurationProvider": "ms-vscode.cmake-tools"
-        }
-    ],
-    "version": 4
+  "version": 4,
+  "configurations": [
+    {
+      "name": "Windows-Clang",
+      "configurationProvider": "ms-vscode.cmake-tools",
+      "intelliSenseMode": "windows-clang-x64",
+      "compilerPath": "C:/Program Files/LLVM/bin/clang++.exe",
+      "cStandard": "c17",
+      "cppStandard": "c++17",
+      "compileCommands": "${workspaceFolder}/out/build/default/compile_commands.json"
+
+    }
+  ]
 }

--- a/CMakeUserPresetsVariations.txt
+++ b/CMakeUserPresetsVariations.txt
@@ -1,0 +1,43 @@
+{
+  "version": 5,
+  "configurePresets": [
+    {
+      "name": "default",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/out/build/default",
+      "cacheVariables": {
+        "CMAKE_C_COMPILER": "C:/Program Files/LLVM/bin/clang.exe",
+        "CMAKE_CXX_COMPILER": "C:/Program Files/LLVM/bin/clang++.exe",
+        "CMAKE_MAKE_PROGRAM": "C:/Program Files/Ninja/ninja.exe",
+        "CMAKE_TOOLCHAIN_FILE": "C:/Users/ehdec/vcpkg/scripts/buildsystems/vcpkg.cmake",
+        "VCPKG_ROOT": "C:/Users/ehdec/vcpkg",
+        "VCPKG_TARGET_TRIPLET": "x64-windows",
+        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
+      }
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "default",
+      "configurePreset": "default",
+      "targets": [ "all" ],
+      "jobs": 8
+    }
+  ]
+}
+
+
+{
+   "version": 2,
+   "configurePresets": [
+      {
+         "name": "default",
+         "inherits": "vcpkg-template-preset",
+         "environment": {
+            "VCPKG_ROOT": "C:/Users/ehdec/vcpkg",
+            "CMAKE_C_COMPILER": "C:/Program Files/LLVM/bin/clang.exe",
+            "CMAKE_CXX_COMPILER": "C:/Program Files/LLVM/bin/clang++.exe"
+         }
+      }
+   ]
+}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,11 +1,7 @@
 {
   "dependencies": [
     "glm",
-    {
-      "name": "glfw3",
-      "features": [
-        "wayland"
-      ]
-    }
+    "glfw3",
+    "glad"
   ]
 }


### PR DESCRIPTION
Changed c_cpp_properties.json to be windows format. Changed vcpkg.json to use glfw3 and glad instead of wayland.

Downloaded GIT, ninja, cmake, VS Studio Build Tools 2022 (with C++ Clang tools for windows component),git c